### PR TITLE
US #1 - BE - Add query and test for image for user

### DIFF
--- a/code/api/src/modules/user/types.js
+++ b/code/api/src/modules/user/types.js
@@ -13,7 +13,8 @@ const UserType = new GraphQLObjectType({
     password: { type: GraphQLString },
     role: { type: GraphQLString },
     createdAt: { type: GraphQLString },
-    updatedAt: { type: GraphQLString }
+    updatedAt: { type: GraphQLString },
+    image: { type: GraphQLString }
   })
 })
 

--- a/code/api/src/seeders/1-user.js
+++ b/code/api/src/seeders/1-user.js
@@ -8,6 +8,7 @@ module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.bulkInsert('users', [
       {
+        id: 1,
         name: 'The Admin',
         email: 'admin@crate.com',
         password: bcrypt.hashSync('123456', config.saltRounds),
@@ -17,6 +18,7 @@ module.exports = {
         image: 'https://do.lolwot.com/wp-content/uploads/2015/06/18-hilarious-and-bizarre-stock-photos-15.jpg'
       },
       {
+        id: 2,
         name: 'The User',
         email: 'user@crate.com',
         password: bcrypt.hashSync('123456', config.saltRounds),

--- a/code/api/test/users/email-test.js
+++ b/code/api/test/users/email-test.js
@@ -17,4 +17,17 @@ describe('GraphQL', () => {
         done();
     })
   })
+
+  it('Returns an email address for each user in an All Users request', (done) => {
+    request.post('/graphql')
+    .send({ query: '{ users { email } }'})
+    .expect(200)
+    .end((err,res) => {
+        if (err) return done(err);
+        res.body.data.users.should.be.a('array')
+        res.body.data.users[1].should.have.property('email')
+        expect(res.body.data.users[1].email).to.eq('user@crate.com')
+        done();
+    })
+  })
 });

--- a/code/api/test/users/image-test.js
+++ b/code/api/test/users/image-test.js
@@ -1,0 +1,34 @@
+const chai = require('chai');
+
+const expect = chai.expect;
+const should = chai.should();
+const url = `http://localhost:8000/`;
+const request = require('supertest')(url);
+
+describe('GraphQL', () => {
+  it('Returns image url for user with id = 2', (done) => {
+    request.post('/graphql')
+    .send({ query: '{ user(id: 2) { image } }'})
+    .expect(200)
+    .end((err,res) => {
+        if (err) return done(err); // Let's research and understand this. Is it a mocha built in?
+        res.body.data.user.should.have.property('image')
+        expect(res.body.data.user.image).to.eq('https://en.pimg.jp/045/948/028/1/45948028.jpg')
+        done();
+    })
+  })
+
+  it('Returns an image url for each user in an All Users request', (done) => {
+    request.post('/graphql')
+    .send({ query: '{ users { image } }'})
+    .expect(200)
+    .end((err,res) => {
+        if (err) return done(err);
+        res.body.data.users.should.be.a('array')
+        // write a length test? - like since we know we only have 2 users?
+        res.body.data.users[0].should.have.property('image')
+        expect(res.body.data.users[0].image).to.eq('https://do.lolwot.com/wp-content/uploads/2015/06/18-hilarious-and-bizarre-stock-photos-15.jpg')
+        done();
+    })
+  })
+});


### PR DESCRIPTION
Collaborators on this code:
@leahriffell 
@judithpillado 

**What was changed**
- Type file: Added image column as graphql object
- Seeder file: Hardcoded id's for primary key issues in testing
- Test file(s):
  - Email: adds an all users test
  - Image: tests if getUser can call image; also test is all users can call image

**Outstanding Questions**
- How can we make these tests more robust?

closes #6 
closes #7 