### PR TITLE
US #1 - BE - Add mutation and test for post user's image

### DIFF
--- a/code/api/src/modules/user/mutations.js
+++ b/code/api/src/modules/user/mutations.js
@@ -3,7 +3,7 @@ import { GraphQLString, GraphQLInt } from 'graphql'
 
 // App Imports
 import { UserType } from './types'
-import { create, remove } from './resolvers'
+import { create, remove, update } from './resolvers'
 
 // Create
 export const userSignup = {
@@ -25,6 +25,23 @@ export const userSignup = {
     }
   },
   resolve: create
+}
+
+// Update
+export const userUpdate = {
+  type: UserType,
+  args: {
+    id: {
+      name: 'id',
+      type: GraphQLInt
+    },
+
+    image: {
+      name: 'image',
+      type: GraphQLString
+    }
+  },
+  resolve: update
 }
 
 // Remove

--- a/code/api/src/modules/user/resolvers.js
+++ b/code/api/src/modules/user/resolvers.js
@@ -27,6 +27,26 @@ export async function create(parentValue, { name, email, password }) {
   }
 }
 
+// Update user
+export async function update(parentValue, { id, image }, { auth }) {
+  if(auth.user) {
+    const user = await models.User.update(
+      {
+        image
+      },
+      {where: {id}}
+    )
+    
+    if(!user) {
+      throw Error('No user exists.')
+    } else {
+      return await models.User.findOne({ where: { id } })
+    };
+  } else {
+    throw new Error('Operation denied.')
+  }
+}
+
 export async function login(parentValue, { email, password }) {
   const user = await models.User.findOne({ where: { email } })
 

--- a/code/api/test/users/image-test.js
+++ b/code/api/test/users/image-test.js
@@ -31,4 +31,18 @@ describe('GraphQL', () => {
         done();
     })
   })
+
+  it('Update image url for user with id = 2', (done) => {
+    // can we do an intial test that initial value is img value before update?
+
+    request.post('/graphql')
+    .send({ query: 'mutation { userUpdate(id: 2, image: "updated_img.png") { id image } }'})
+    .expect(200)
+    .end((err,res) => {
+        if (err) return done(err);
+        res.body.data.userUpdate.should.have.property('image')
+        expect(res.body.data.userUpdate.image).to.eq('updated_img.png')
+        done();
+    })
+  })
 });


### PR DESCRIPTION
**What was changed**
- Created mutation for post/edit user image
- Added test that image updates

**Notes**
- Tried to add test setup that user's initial image is existing value, but was running into errors
- The tests are hitting our real dev database (no good, let's figure out a test db environment)
- Mutate image endpoint explicitly returns back updated user info (as opposed to other update endpoints we have that return 'null')

closes #4
closes #5 