### PR TITLE
US #4 - BE - Add shipping address details (5 columns) to user table in db

### DIFF
--- a/code/api/src/migrations/7-user-add-address.js
+++ b/code/api/src/migrations/7-user-add-address.js
@@ -7,6 +7,7 @@ module.exports = {
         type: Sequelize.STRING
       }),
       queryInterface.addColumn('users', 'address_line2', {
+        allowNull: true,
         type: Sequelize.STRING
       }),
       queryInterface.addColumn('users', 'city', {

--- a/code/api/src/migrations/7-user-add-address.js
+++ b/code/api/src/migrations/7-user-add-address.js
@@ -1,0 +1,33 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return Promise.all([
+      queryInterface.addColumn('users', 'address_line1', {
+        type: Sequelize.STRING
+      }),
+      queryInterface.addColumn('users', 'address_line2', {
+        type: Sequelize.STRING
+      }),
+      queryInterface.addColumn('users', 'city', {
+        type: Sequelize.STRING
+      }),
+      queryInterface.addColumn('users', 'state', {
+        type: Sequelize.STRING
+      }),
+      queryInterface.addColumn('users', 'zipcode', {
+        type: Sequelize.INTEGER
+      })
+    ]);
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return Promise.all([
+      queryInterface.removeColumn('users', 'address_line1'),
+      queryInterface.removeColumn('users', 'address_line2'),
+      queryInterface.removeColumn('users', 'city'),
+      queryInterface.removeColumn('users', 'state'),
+      queryInterface.removeColumn('users', 'zipcode')
+    ]);
+  }
+};

--- a/code/api/src/modules/user/model.js
+++ b/code/api/src/modules/user/model.js
@@ -17,6 +17,21 @@ module.exports = function(sequelize, DataTypes) {
     },
     image: {
       type: DataTypes.TEXT
+    },
+    address_line1: {
+      type: DataTypes.STRING
+    },
+    address_line2: {
+      type: DataTypes.STRING
+    },
+    city: {
+      type: DataTypes.STRING
+    },
+    state: {
+      type: DataTypes.STRING
+    },
+    zipcode: {
+      type: DataTypes.INTEGER
     }
   })
 

--- a/code/api/src/seeders/1-user.js
+++ b/code/api/src/seeders/1-user.js
@@ -15,7 +15,12 @@ module.exports = {
         role: params.user.roles.admin,
         createdAt: new Date(),
         updatedAt: new Date(),
-        image: 'https://do.lolwot.com/wp-content/uploads/2015/06/18-hilarious-and-bizarre-stock-photos-15.jpg'
+        image: 'https://do.lolwot.com/wp-content/uploads/2015/06/18-hilarious-and-bizarre-stock-photos-15.jpg',
+        address_line1: '1234 There Blvd',
+        address_line2: 'PO BOX 801234',
+        city: 'Denver',
+        state: 'CO',
+        zipcode: 36479
       },
       {
         id: 2,
@@ -25,7 +30,11 @@ module.exports = {
         role: params.user.roles.user,
         createdAt: new Date(),
         updatedAt: new Date(),
-        image: 'https://en.pimg.jp/045/948/028/1/45948028.jpg'
+        image: 'https://en.pimg.jp/045/948/028/1/45948028.jpg',
+        address_line1: '5678 Here Ave',
+        city: 'Pueblo',
+        state: 'CO',
+        zipcode: 85623
       }
     ])
   },


### PR DESCRIPTION
**What was changed**
- Migration file: Implemented 5 new columns to user:
  - address_line1 - string
  - address_line2 - string, allows null
  - city - string
  - state - string (could not figure validations/constraints to limit this to 2 characters and only alpha)
  - zipcode - integer (could not figure validations/constraints to limit this to 5 characters)
- Seeder file: Added shipping address for both admin (line 2) and user(no line2) (had to rollback seed file first, and then rerun with new data)
- Model file: Added correct columns for 5 new columns

**Outstanding questions**
- How do we restrict columns? Is this more a frontend thing? When it takes in data from user-facing web app and then sends to api, are restrictions handled here?

closes #28 